### PR TITLE
use a working init.d file

### DIFF
--- a/files/default/hekad.sysv
+++ b/files/default/hekad.sysv
@@ -1,7 +1,4 @@
-#
-# Borrowed from Debian packaging branch https://github.com/mozilla-services/heka/pull/1085/
-#
-
+# Built from /etc/init.d/skeleton
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          heka
@@ -20,7 +17,6 @@ DAEMON=/usr/bin/$NAME
 DAEMON_USER=heka
 DAEMON_ARGS="-config=/etc/heka"
 PIDFILE=/var/run/$NAME.pid
-LOGFILE=/var/log/$NAME.log
 SCRIPTNAME=/etc/init.d/heka
 
 # Exit if the package is not installed
@@ -46,13 +42,10 @@ do_start()
     #   0 if daemon has been started
     #   1 if daemon was already running
     #   2 if daemon could not be started
-    pid=$(pidofproc -p $PIDFILE "$NAME")
-    if [ -n "$pid" ] ; then
-        log_daemon_msg "$desc is already running (PID `cat ${PIDFILE}`)"
-        return 1
-    fi
-    start-stop-daemon --start --quiet --chuid $DAEMON_USER --make-pidfile --background  --pidfile $PIDFILE \
-        --exec $DAEMON -- $DAEMON_ARGS >> $LOGFILE 2>&1 \
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+        || return 1
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+        $DAEMON_ARGS \
         || return 2
     # Add code here, if necessary, that waits for the process to be ready
     # to handle requests from services started subsequently which depend
@@ -117,11 +110,6 @@ case "$1" in
     ;;
   status)
     status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
-    ;;
-  reload|force-reload)
-    log_daemon_msg "Reloading $DESC" "$NAME"
-    do_reload
-    log_end_msg $?
     ;;
   restart|force-reload)
     #

--- a/files/default/hekad.sysv
+++ b/files/default/hekad.sysv
@@ -44,7 +44,7 @@ do_start()
     #   2 if daemon could not be started
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
         || return 1
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --background --exec $DAEMON -- \
         $DAEMON_ARGS \
         || return 2
     # Add code here, if necessary, that waits for the process to be ready


### PR DESCRIPTION
The file that I submitted a few months ago (ecceee6) didn't actually work. I thought I was pulling a boiler-plate file but was not. The service started but didn't actually work as expected.

I just recreated the file using /etc/init.d/skeleton and have verified that service hekad start, status, stop, restart and force-reload all work