### PR TITLE
update tk platform versions / remove potential documentation gotcha

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,12 +6,12 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: debian-8.4
-  - name: ubuntu-12.04
+  - name: debian-7.11
+  - name: debian-8.8
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: centos-6.7
-  - name: centos-7.2
+  - name: centos-6.9
+  - name: centos-7.3
   - name: osx-10.10
 
 suites:

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -39,7 +39,7 @@ end
 systemd_service 'hekad' do
   unit do
     description 'general purpose data acquisition and processing engine'
-    documentation ['man:hekad(1)', 'https://hekad.readthedocs.io']
+    documentation ['https://hekad.readthedocs.io']
   end
   install do
     wanted_by 'multi-user.target'


### PR DESCRIPTION
* update tk platform versions
* removes the manual reference in heka's unit_documentation. if a heka package doesnt install manual pages the unit validation will fail during installation. not a problem in this cookbook when using the default heka package/version, but ymmv if you override those attributes.

see the "Examples for Verify" section here:  https://www.freedesktop.org/software/systemd/man/systemd-analyze.html
